### PR TITLE
Fix discount type comparison in invoice

### DIFF
--- a/MiniShop/Controllers/InvoiceController.cs
+++ b/MiniShop/Controllers/InvoiceController.cs
@@ -68,7 +68,7 @@ namespace MiniShop.Controllers
             var discounts = await _repository.Discount.GetAllDiscounts();
             foreach (var discount in discounts)
             {
-                if (discount.Equals(customer.CustomerType) && discount.IsRatePercentage)
+                if (discount.Type.Equals(customer.CustomerType, StringComparison.OrdinalIgnoreCase) && discount.IsRatePercentage)
                 {
                     var discountValue = invoiceDto.OrderTotal * (discount.Rate / 100);
                     invoiceSubtotal = invoiceDto.OrderTotal - discountValue;


### PR DESCRIPTION
## Summary
- ensure `ApplyDiscount` compares discount types case-insensitively

## Testing
- `dotnet test MiniShop.sln` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684733df7ca88332be8eec1e0c2fa667